### PR TITLE
Add tenant release plan for triggers

### DIFF
--- a/.konflux/next/release-plan.yaml
+++ b/.konflux/next/release-plan.yaml
@@ -23,7 +23,7 @@ spec:
         - name: tektoncd-triggers-next-eventlistenersink
           repository: "quay.io/openshift-pipelines/openshift-pipelines-pipelines-triggers-eventlistenersink-rhel8"
           tags: [next]
-  pipeline:
+  tenantPipeline:
     pipelineRef:
       resolver: git
       params:

--- a/.konflux/next/release-plan.yaml
+++ b/.konflux/next/release-plan.yaml
@@ -1,0 +1,36 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'true'
+    release.appstudio.openshift.io/standing-attribution: 'true'
+  name: tektoncd-triggers-next-rp
+  namespace: tekton-ecosystem-tenant
+spec:
+  application: tektoncd-triggers-next
+  data:
+    mapping:
+      components:
+        - name: tektoncd-triggers-next-webhook
+          repository: "quay.io/openshift-pipelines/openshift-pipelines-pipelines-triggers-webhook-rhel8"
+          tags: [next]
+        - name: tektoncd-triggers-next-controller
+          repository: "quay.io/openshift-pipeline/openshift-pipelines-pipelines-triggers-controller-rhel8"
+          tags: [next]
+        - name: tektoncd-triggers-next-core-interceptors
+          repository: "quay.io/openshift-pipelines/openshift-pipelines-pipelines-triggers-core-interceptors-rhel8"
+          tags: [next]
+        - name: tektoncd-triggers-next-eventlistenersink
+          repository: "quay.io/openshift-pipelines/openshift-pipelines-pipelines-triggers-eventlistenersink-rhel8"
+          tags: [next]
+  pipeline:
+    pipelineRef:
+      resolver: git
+      params:
+        - name: url
+          value: "https://github.com/konflux-ci/release-service-catalog.git"
+        - name: revision
+          value: production
+        - name: pathInRepo
+          value: "pipelines/push-to-external-registry/push-to-external-registry.yaml"
+    serviceAccountName: appstudio-pipeline

--- a/.konflux/next/release.yaml
+++ b/.konflux/next/release.yaml
@@ -1,0 +1,8 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+ name: tektoncd-triggers-next-elease
+ namespace: tekton-ecosystem-tenant
+spec:
+ releasePlan: tektoncd-triggers-next-rp
+ snapshot: tektoncd-triggers-next-snapshot


### PR DESCRIPTION
Konflux allow us to add release plan for development team to release thier images to some place without sending to production