### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tektoncd-triggers-1-19-controller

### DIFF
--- a/.konflux/dockerfiles/controller.Dockerfile
+++ b/.konflux/dockerfiles/controller.Dockerfile
@@ -27,6 +27,7 @@ LABEL \
       com.redhat.component="openshift-pipelines-triggers-controller-rhel9-container" \
       name="openshift-pipelines/pipelines-triggers-controller-rhel9" \
       version=$VERSION \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.19::el9" \
       summary="Red Hat OpenShift Pipelines Triggers Controller" \
       maintainer="pipelines-extcomm@redhat.com" \
       description="Red Hat OpenShift Pipelines Triggers Controller" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
