### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tektoncd-triggers-1-14-core-interceptors

### DIFF
--- a/.konflux/dockerfiles/core-interceptors.Dockerfile
+++ b/.konflux/dockerfiles/core-interceptors.Dockerfile
@@ -26,6 +26,7 @@ LABEL \
       com.redhat.component="openshift-pipelines-triggers-core-interceptors-rhel8-container" \
       name="openshift-pipelines/pipelines-triggers-core-interceptors-rhel8" \
       version=$VERSION \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.14::el8" \
       summary="Red Hat OpenShift Pipelines Triggers Core Interceptors" \
       maintainer="pipelines-extcomm@redhat.com" \
       description="Red Hat OpenShift Pipelines Triggers Core Interceptors" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
